### PR TITLE
Add setup and usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # production-plan
+
+## Setup
+
+1. Ensure Python 3.11 or newer is installed.
+2. (Optional) Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install the required packages:
+   ```bash
+   pip install pandas numpy openpyxl
+   ```
+
+## GUI
+
+Launch the Tkinter interface with:
+
+```bash
+python gui.py
+```
+
+Choose the input Excel workbook (defaults to `SPP.xlsx`), select an output location and click **Run**.
+
+Example window:
+
+![GUI example](docs/gui_example.svg)
+
+## CLI
+
+Run the transformations directly from the command line:
+
+```bash
+python main.py
+```
+
+The script reads `SPP.xlsx` and writes results to `outputs/SPP_results.xlsx`.
+To specify custom paths:
+
+```bash
+python -c "from main import main; main({'input_xlsx': 'my_input.xlsx', 'output_xlsx': 'outputs/my_results.xlsx'})"
+```

--- a/docs/gui_example.svg
+++ b/docs/gui_example.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="160">
+  <rect width="400" height="160" fill="#ffffff" stroke="#000000"/>
+  <text x="10" y="20" font-family="sans-serif" font-size="16">Production Plan</text>
+  <text x="10" y="50" font-family="sans-serif" font-size="14">Input Excel:</text>
+  <rect x="110" y="35" width="200" height="20" fill="#f0f0f0" stroke="#000000"/>
+  <text x="115" y="50" font-size="12" font-family="sans-serif">SPP.xlsx</text>
+  <rect x="320" y="35" width="60" height="20" fill="#e0e0e0" stroke="#000000"/>
+  <text x="330" y="50" font-size="12" font-family="sans-serif">Browse</text>
+  <text x="10" y="90" font-size="14" font-family="sans-serif">Output Excel:</text>
+  <rect x="110" y="75" width="200" height="20" fill="#f0f0f0" stroke="#000000"/>
+  <text x="115" y="90" font-size="12" font-family="sans-serif">outputs/SPP_results.xlsx</text>
+  <rect x="320" y="75" width="60" height="20" fill="#e0e0e0" stroke="#000000"/>
+  <text x="330" y="90" font-size="12" font-family="sans-serif">Browse</text>
+  <rect x="170" y="110" width="60" height="25" fill="#d0d0d0" stroke="#000000"/>
+  <text x="187" y="127" font-size="14" font-family="sans-serif">Run</text>
+</svg>


### PR DESCRIPTION
## Summary
- document Python dependencies and virtual environment setup
- add GUI launch instructions with illustrative screenshot
- show command-line examples for running transformations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pandas openpyxl numpy` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba988ad3c4833195bc1972e2bb83cd