### PR TITLE
Add Streamlit UI for running production plan

### DIFF
--- a/models/main.py
+++ b/models/main.py
@@ -51,20 +51,38 @@ def _pick_sheet(sheets, *names):
     return None
 
 
-def main():
-    USER = os.getlogin()
 
-    ROOT = Path(
-        fr"C:\Users\{USER}\Ambatovy\DMSA - Asset Performance & Excellence - Documents"
-        r"\Strategy and Standardization\3. Improvement Projects\9. Smart Production Plan"
-        r"\SPP development\Python"
-    )
-    INPUT_XLSX = Path(
-        fr"C:\Users\{USER}\Ambatovy\DMSA - Asset Performance & Excellence - Documents"
-        r"\Strategy and Standardization\3. Improvement Projects\9. Smart Production Plan"
-        r"\SPP development\SPP.xlsx"
-    )
-    OUTPUT_DIR = ROOT / "outputs"
+def main(spp_path: str | Path | None = None, output_dir: str | Path | None = None):
+    """Run the Smart Production Plan calculation.
+
+    Parameters
+    ----------
+    spp_path : str or Path, optional
+        Path to the ``SPP.xlsx`` input file. When ``None`` the original
+        Windows-specific default location is used.
+    output_dir : str or Path, optional
+        Directory where the resulting ``SPP_results.xlsx`` file will be written.
+        When ``None`` the original ``outputs`` directory inside the Ambatovy
+        project path is used.
+    """
+    if spp_path is None or output_dir is None:
+        USER = os.getlogin()
+
+        ROOT = Path(
+            fr"C:\Users\{USER}\Ambatovy\DMSA - Asset Performance & Excellence - Documents"
+            r"\Strategy and Standardization\3. Improvement Projects\9. Smart Production Plan"
+            r"\SPP development\Python"
+        )
+        INPUT_XLSX = Path(
+            fr"C:\Users\{USER}\Ambatovy\DMSA - Asset Performance & Excellence - Documents"
+            r"\Strategy and Standardization\3. Improvement Projects\9. Smart Production Plan"
+            r"\SPP development\SPP.xlsx"
+        )
+        OUTPUT_DIR = ROOT / "outputs"
+    else:
+        INPUT_XLSX = Path(spp_path)
+        OUTPUT_DIR = Path(output_dir)
+
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     OUTPUT_XLSX = OUTPUT_DIR / "SPP_results.xlsx"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 openpyxl
 pandas
+streamlit

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,34 @@
+import tempfile
+from pathlib import Path
+
+import streamlit as st
+
+from models.main import main as run_main
+
+st.title("Production Plan Calculator")
+
+st.write(
+    "Upload an `SPP.xlsx` file or use the bundled sample to run the production plan "
+    "calculation. The results will be written to `SPP_results.xlsx`."
+)
+
+uploaded = st.file_uploader("SPP.xlsx", type=["xlsx"])
+
+if st.button("Run calculation"):
+    if uploaded is not None:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx") as tmp:
+            tmp.write(uploaded.getbuffer())
+            input_path = Path(tmp.name)
+    else:
+        input_path = Path("data/input/SPP.xlsx")
+    output_dir = Path("web_outputs")
+    run_main(spp_path=input_path, output_dir=output_dir)
+    result_file = output_dir / "SPP_results.xlsx"
+    if result_file.exists():
+        st.success("Calculation complete.")
+        with open(result_file, "rb") as fh:
+            st.download_button(
+                label="Download results", data=fh, file_name="SPP_results.xlsx"
+            )
+    else:
+        st.error("No results produced.")


### PR DESCRIPTION
## Summary
- parameterize `main()` to accept input and output paths
- add Streamlit webapp for triggering the calculation and downloading results
- include Streamlit in dependencies

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openpyxl)*
- `python - <<'PY'
from models.main import main
main('data/input/SPP.xlsx', 'outputs')
PY` *(fails: ModuleNotFoundError: No module named 'openpyxl')*


------
https://chatgpt.com/codex/tasks/task_e_68bd4b6718708331ba8a98e3908e976d