### PR TITLE
Add Flask server for SPP upload and results download

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 
 Python models + input spreadsheet for production planning
 
+## Web Server
+
+Install the dependencies and start the Flask server:
+
+```
+pip install -r requirements.txt
+python server.py
+```
+
+Then visit [http://localhost:5000/](http://localhost:5000/) in your browser to upload
+an `SPP.xlsx` file and download the generated `SPP_results.xlsx`.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 openpyxl
 pandas
 streamlit
+Flask

--- a/server.py
+++ b/server.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from flask import Flask, render_template, request, send_file
+
+from models.main import main as run_main
+
+app = Flask(__name__)
+
+
+@app.get("/")
+def index():
+    """Render file upload form."""
+    return render_template("index.html")
+
+
+@app.post("/run")
+def run_calculation():
+    """Accept an uploaded SPP.xlsx, run the model, and return results."""
+    uploaded = request.files.get("spp_file")
+    if uploaded is None or uploaded.filename == "":
+        return ("No file uploaded", 400)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        input_path = tmpdir_path / "SPP.xlsx"
+        uploaded.save(input_path)
+        output_dir = tmpdir_path
+        run_main(spp_path=input_path, output_dir=output_dir)
+        result_file = output_dir / "SPP_results.xlsx"
+        if not result_file.exists():
+            return ("No results produced", 500)
+        return send_file(result_file, as_attachment=True, download_name="SPP_results.xlsx")
+
+
+if __name__ == "__main__":
+    app.run()

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Production Plan Upload</title>
+</head>
+<body>
+    <h1>Upload SPP.xlsx</h1>
+    <form action="/run" method="post" enctype="multipart/form-data">
+        <input type="file" name="spp_file" accept=".xlsx" required>
+        <button type="submit">Run</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask dependency
- create Flask server to upload `SPP.xlsx` and return `SPP_results.xlsx`
- document how to start the server and use the web interface

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd7a29ee98833185d3b32f489ebcc5